### PR TITLE
fix: Run uvicorn programmatically instead of subprocess for .exe

### DIFF
--- a/BUILD_AND_SHARE.bat
+++ b/BUILD_AND_SHARE.bat
@@ -47,8 +47,21 @@ pyinstaller --name="ReadySetBet" ^
   --hidden-import=websockets ^
   --hidden-import=PIL ^
   --hidden-import=uvicorn ^
+  --hidden-import=uvicorn.logging ^
+  --hidden-import=uvicorn.loops ^
+  --hidden-import=uvicorn.loops.auto ^
+  --hidden-import=uvicorn.protocols ^
+  --hidden-import=uvicorn.protocols.http ^
+  --hidden-import=uvicorn.protocols.http.auto ^
+  --hidden-import=uvicorn.lifespan ^
+  --hidden-import=uvicorn.lifespan.on ^
   --hidden-import=fastapi ^
   --hidden-import=sqlalchemy ^
+  --hidden-import=sqlalchemy.ext.declarative ^
+  --hidden-import=pydantic ^
+  --hidden-import=starlette ^
+  --collect-all=uvicorn ^
+  --collect-all=fastapi ^
   --clean ^
   --noconfirm ^
   unified_launcher.py


### PR DESCRIPTION
ROOT CAUSE:
When PyInstaller builds a .exe, sys.executable points to ReadySetBet.exe (not python.exe). The code was trying to run:
  ReadySetBet.exe -m uvicorn server.main:app
This doesn't work - .exe files can't run Python modules!

SOLUTION:
Start uvicorn programmatically using uvicorn.run() in a background thread instead of subprocess.Popen(). This works perfectly within a .exe.

CHANGES:

1. unified_launcher.py:
   - Import FastAPI app directly: from server.main import app
   - Start uvicorn in background thread: uvicorn.run(app, host, port)
   - Use daemon=False so server keeps running after launcher closes
   - Removed all subprocess code (no more Popen, no stdout/stderr pipes)
   - Increased max attempts to 30 (15 seconds) for server startup
   - Better error messages for common issues (port already in use)

2. BUILD_AND_SHARE.bat:
   - Added comprehensive uvicorn hidden imports: * uvicorn.logging, uvicorn.loops, uvicorn.protocols, etc.
   - Added --collect-all=uvicorn and --collect-all=fastapi
   - Added sqlalchemy.ext.declarative, pydantic, starlette imports
   - Ensures all server dependencies are bundled in .exe

BENEFITS:
- Works correctly in .exe (no Python subprocess needed)
- Server runs in same process as game (cleaner architecture)
- Better error handling (no subprocess complexity)
- Faster startup (no process spawning overhead)
- Simpler code (no stdout/stderr pipe handling)

Now the logs will show:
"Starting uvicorn server programmatically..."
"✓ Server thread started (will keep running)"

Instead of trying to run ReadySetBet.exe as Python!