### PR TITLE
fix: Make session info popup non-modal to allow game interaction

### DIFF
--- a/src/multiplayer_app.py
+++ b/src/multiplayer_app.py
@@ -163,7 +163,8 @@ class MultiplayerReadySetBetApp(ModernReadySetBetApp):
         info_window.title("Game Created!")
         info_window.geometry("550x400")
         info_window.transient(self.root)
-        info_window.grab_set()
+        # Don't use grab_set() - allows clicking on game board while popup is visible
+        info_window.attributes("-topmost", True)  # Keep popup visible but not blocking
 
         # Container
         container = ctk.CTkFrame(info_window, fg_color="transparent")
@@ -237,12 +238,21 @@ class MultiplayerReadySetBetApp(ModernReadySetBetApp):
             font=("Arial", 12),
             text_color="yellow"
         )
-        hint.pack(pady=(0, 20))
+        hint.pack(pady=(0, 10))
+
+        # Note about non-blocking
+        note = ctk.CTkLabel(
+            container,
+            text="You can start playing! This window won't block the game.",
+            font=("Arial", 11),
+            text_color="lightgray"
+        )
+        note.pack(pady=(0, 20))
 
         # Close button
         close_btn = ctk.CTkButton(
             container,
-            text="Got It!",
+            text="Close (or keep open for reference)",
             command=info_window.destroy,
             height=45,
             font=("Arial", 14, "bold"),


### PR DESCRIPTION
PROBLEM:
User reported: "The game created popup does not allow me to click any button on the actual game board window"

The session info popup was modal (grab_set()) which blocked all interaction with the game window behind it. Users had to close the popup before they could start playing or invite players.

ROOT CAUSE:
info_window.grab_set() makes the popup modal, capturing all input and preventing clicks on any other window.

SOLUTION:

1. Removed grab_set():
   - Popup is now non-modal
   - Users can click on game board while popup is visible
   - Can leave popup open for easy copy/paste of session info

2. Added attributes("-topmost", True):
   - Keeps popup visible on top
   - Easy to reference while playing
   - Doesn't disappear behind game window

3. Added helpful text:
   - "You can start playing! This window won't block the game."
   - Makes it clear the popup is non-blocking

4. Updated button text:
   - "Close (or keep open for reference)"
   - Indicates users can leave it open

BENEFITS:
- Host can start setting up the game immediately
- Can keep session info visible for when friends join
- No need to memorize or write down session code
- Better UX - no forced modal interruption

Now users can:
1. See session info popup
2. Click on game board to add players/place bets
3. Keep popup open to share info with joining friends
4. Close popup whenever they want